### PR TITLE
Nissix plugin scope-packages on react-sequence-animator

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,4 @@
-const yoshiWebpackConfig = require('yoshi/config/webpack.config.storybook');
+const yoshiWebpackConfig = require('@wix/yoshi/config/webpack.config.storybook');
 const remove = require('lodash/remove');
 
 module.exports = (config, env, defaultConfig) => {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-test-renderer": "~15.6.0",
     "storybook-readme": "^3.3.0",
     "wix-style-react": "^4.9.0",
-    "yoshi": "^2.1.2"
+    "@wix/yoshi": "^2.1.2"
   },
   "yoshi": {
     "entry": {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.314s



Output Log:
Migrating package "react-sequence-animator" in .


## Migration from non scope to @wix/scoped packages
> /tmp/1ebc618d53a3316d4673f72d7181c15f

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
.storybook/webpack.config.js
```

